### PR TITLE
Use wrapping_add to prevent error on debug mode

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,7 @@ fn trie_match_inner(input: ExprMatch) -> Result<TokenStream, Error> {
             let mut pos = 0;
             for &b in query.as_bytes() {
                 let base = *bases.get_unchecked(pos);
-                pos = (base + i32::from(b)) as usize;
+                pos = base.wrapping_add(i32::from(b)) as usize;
                 if let Some(out_check) = out_checks.get(pos) {
                     if out_check & 0xff == u32::from(b) {
                         continue;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -45,6 +45,7 @@ fn test_match_wildcard() {
     );
 }
 
+// Issue: https://github.com/daac-tools/trie-match/pull/4
 #[test]
 fn test_match_only_wildcard() {
     let text = "ba";

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -44,3 +44,14 @@ fn test_match_wildcard() {
         4,
     );
 }
+
+#[test]
+fn test_match_only_wildcard() {
+    let text = "ba";
+    assert_eq!(
+        trie_match!(match text {
+            _ => 4,
+        }),
+        4,
+    );
+}


### PR DESCRIPTION
The current double-array trie implementation uses `i32::MAX` for the invalid base value, so that `bases.get(base+char)` always returns `None`.
However, using the normal addition operator (`+`) for addition causes panic with the message  `attempt to add with overflow` in debug mode when overflow occurs, so this branch change it to use `wrapping_add()`

