### PR TITLE
Use enum for value

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
           - nightly
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "trie-match"
 version = "0.1.1"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.65"
 authors = [
     "Koichi Akabe <vbkaisetsu@gmail.com>",
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@ fn retrieve_match_patterns(pat: &Pat) -> Result<Vec<Option<String>>, Error> {
 }
 
 struct MatchInfo {
-    bodies: Vec<Box<Expr>>,
+    bodies: Vec<Expr>,
     pattern_map: HashMap<String, usize>,
     wildcard_idx: usize,
 }
@@ -127,7 +127,7 @@ fn parse_match_arms(arms: &[Arm]) -> Result<MatchInfo, Error> {
             body,
             ..
         },
-    ) in arms.into_iter().enumerate()
+    ) in arms.iter().enumerate()
     {
         if let Some(attr) = attrs.first() {
             return Err(Error::new(attr.span(), "attribute not supported here"));
@@ -135,7 +135,7 @@ fn parse_match_arms(arms: &[Arm]) -> Result<MatchInfo, Error> {
         if let Some((if_token, _)) = guard {
             return Err(Error::new(if_token.span(), "match guard not supported"));
         }
-        let pat_strs = retrieve_match_patterns(&pat)?;
+        let pat_strs = retrieve_match_patterns(pat)?;
         for pat_str in pat_strs {
             if let Some(pat_str) = pat_str {
                 if pattern_map.contains_key(&pat_str) {
@@ -149,7 +149,7 @@ fn parse_match_arms(arms: &[Arm]) -> Result<MatchInfo, Error> {
                 wildcard_idx.replace(i);
             }
         }
-        bodies.push(body.clone());
+        bodies.push(*body.clone());
     }
     let Some(wildcard_idx) = wildcard_idx else {
         return Err(Error::new(

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -77,14 +77,14 @@ impl<T> Sparse<T> {
     ///
     /// # Returns
     ///
-    /// The first item is a `base` array, and the second item is `out_check` array.
+    /// A tuple of a base array, a check array, and a value array.
     pub fn build_double_array_trie(&self, wildcard_value: T) -> (Vec<i32>, Vec<u8>, Vec<T>)
     where
         T: Copy,
     {
         let mut bases = vec![i32::MAX];
-        let mut outs = vec![wildcard_value];
         let mut checks = vec![0];
+        let mut values = vec![wildcard_value];
         let mut is_used = vec![true];
         let mut stack = vec![(0, 0)];
         let mut used_bases = HashSet::new();
@@ -92,7 +92,7 @@ impl<T> Sparse<T> {
         while let Some((state_id, da_pos)) = stack.pop() {
             let state = &self.states[state_id];
             if let Some(val) = state.value {
-                outs[da_pos] = val;
+                values[da_pos] = val;
             }
             for &u in &is_used[usize::try_from(search_start).unwrap()..] {
                 if !u {
@@ -108,7 +108,7 @@ impl<T> Sparse<T> {
                     if child_da_pos >= bases.len() {
                         bases.resize(child_da_pos + 1, i32::MAX);
                         checks.resize(child_da_pos + 1, 0);
-                        outs.resize(child_da_pos + 1, wildcard_value);
+                        values.resize(child_da_pos + 1, wildcard_value);
                         is_used.resize(child_da_pos + 1, false);
                     }
                     checks[child_da_pos] = k;
@@ -117,6 +117,6 @@ impl<T> Sparse<T> {
                 }
             }
         }
-        (bases, checks, outs)
+        (bases, checks, values)
     }
 }


### PR DESCRIPTION
The current implementation uses u32 values for output values, so it is necessary to use `unreachable_unchecked()` at the last branch of the match expression.
This PR uses an `enum` instead, so it can remove such unsafe code.