### PR TITLE
Support `cfg` attribute on Nightly Rust

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,7 +50,8 @@ jobs:
         run: cargo test
 
       - name: Run cargo doc
-        run: cargo doc --release --all-features
+        if: ${{ matrix.rust == 'nightly' }}
+        run: cargo doc --release
         env:
           RUSTDOCFLAGS: "-Dwarnings"
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,8 +46,11 @@ jobs:
         run: cargo clippy -- -D warnings -W clippy::nursery -W clippy::pedantic
 
       - name: Run cargo test
-        continue-on-error: ${{ matrix.rust == 'nightly' }}
         run: cargo test
+
+      - name: Run cargo test feature=cfg_attribute
+        if: ${{ matrix.rust == 'nightly' }}
+        run: cargo test --features cfg_attribute
 
       - name: Run cargo doc
         if: ${{ matrix.rust == 'nightly' }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,9 +48,9 @@ jobs:
       - name: Run cargo test
         run: cargo test
 
-      - name: Run cargo test feature=cfg_attribute
+      - name: Run cargo test all features
         if: ${{ matrix.rust == 'nightly' }}
-        run: cargo test --features cfg_attribute
+        run: cargo test --all-features
 
       - name: Run cargo doc
         if: ${{ matrix.rust == 'nightly' }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Run cargo doc
         if: ${{ matrix.rust == 'nightly' }}
-        run: cargo doc --release
+        run: cargo doc --release --all-features
         env:
           RUSTDOCFLAGS: "-Dwarnings"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,17 @@ syn = { version = "2.0", features = ["full", "extra-traits"] } # MIT or Apache-2
 proc-macro2 = "1.0" # MIT or Apache-2.0
 quote = "1.0" # MIT or Apache-2.0
 
+[features]
+# Nightly only
+cfg_attribute = []
+
 [dev-dependencies]
 criterion = { version = "0.4.0", features = ["html_reports"] } # MIT or Apache-2.0
 
 [[bench]]
 name = "match"
 harness = false
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Furthermore, this implementation uses the compact double-array data structure
 to achieve efficient state-to-state traversal, and the time complexity becomes
 *O(m)*.
 
-## `cfg` attributes
+## `cfg` attribute
 
 Only when using Nightly Rust, this macro supports conditional compilation with
 the `cfg` attribute. To use this feature, enable `features = ["cfg_attribute"]`

--- a/README.md
+++ b/README.md
@@ -62,6 +62,26 @@ Furthermore, this implementation uses the compact double-array data structure
 to achieve efficient state-to-state traversal, and the time complexity becomes
 *O(m)*.
 
+## `cfg` attributes
+
+Only when using Nightly Rust, this macro supports conditional compilation with
+the `cfg` attribute. To use this feature, enable `features = ["cfg_attribute"]`
+in your `Cargo.toml`.
+
+### Example
+
+```rust
+trie_match! {
+    match x {
+        #[cfg(feature = "foo")]
+        "a" => { .. }
+        #[cfg(feature = "bar")]
+        "b" => { .. }
+        _ => { .. }
+    }
+}
+```
+
 ## Limitations
 
 The followings are different from the normal `match` expression:
@@ -70,7 +90,6 @@ The followings are different from the normal `match` expression:
 * The wildcard is evaluated last. (The normal `match` expression does not
   match patterns after the wildcard.)
 * Pattern bindings are unavailable.
-* Attributes for match arms are unavailable.
 * Guards are unavailable.
 
 Sometimes the normal `match` expression is faster, depending on how

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,6 +179,7 @@ fn trie_match_inner(input: ExprMatch) -> Result<TokenStream, Error> {
     let mut wildcard_idx = None;
     let mut built_arms = vec![];
     let mut i = 0;
+    #[allow(clippy::explicit_counter_loop)]
     for Arm {
         attrs,
         pat,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 #![cfg_attr(
     feature = "cfg_attribute",
     doc = r#"
-## `cfg` attributes
+## `cfg` attribute
 
 Only when using Nightly Rust, this macro supports conditional compilation with
 the `cfg` attribute. To use this feature, enable `features = ["cfg_attribute"]`
@@ -262,8 +262,8 @@ fn parse_match_arms(arms: Vec<Arm>) -> Result<MatchInfo, Error> {
         if let Some(attr) = attrs.first() {
             return Err(Error::new(
                 attr.span(),
-                "attribute not supported here (Note: `#[cfg(...)]` attribute is supported only if \
-                the `cfg_attribute` feature is enabled. See the documentation)",
+                "attribute not supported here\nnote: consider enabling the `cfg_attribute` \
+                feature: https://docs.rs/trie-match/latest/trie_match/#cfg-attribute",
             ));
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,7 +204,6 @@ fn trie_match_inner(input: ExprMatch) -> Result<TokenStream, Error> {
             return Err(Error::new(if_token.span(), "match guard not supported"));
         }
         let pat_strs = retrieve_match_patterns(&pat)?;
-        let i_tmp = u32::try_from(i).unwrap();
         for pat_str in pat_strs {
             if let Some(pat_str) = pat_str {
                 if map.contains_key(&pat_str) {
@@ -218,7 +217,7 @@ fn trie_match_inner(input: ExprMatch) -> Result<TokenStream, Error> {
                 wildcard_idx.replace(i);
             }
         }
-        built_arms.push(quote! { #i_tmp => #body });
+        built_arms.push(quote! { #i => #body });
         i += 1;
     }
     if wildcard_idx.is_none() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,7 +216,7 @@ fn retrieve_match_patterns(pat: &Pat) -> Result<Vec<Option<Vec<u8>>>, Error> {
 fn evaluate_cfg_attribute(attrs: &[Attribute]) -> Result<bool, Error> {
     for attr in attrs {
         let ident = attr.path().get_ident().map(Ident::to_string);
-        if ident.as_ref().map(String::as_str) == Some("cfg") {
+        if ident.as_deref() == Some("cfg") {
             if let Meta::List(list) = &attr.meta {
                 let tokens = &list.tokens;
                 let cfg_macro: proc_macro::TokenStream = quote! { cfg!(#tokens) }.into();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,8 @@ let result = trie_match! {
 
 assert_eq!(result, 4);
 ```
-"#)]
+"#
+)]
 //!
 //! ## Limitations
 //!
@@ -179,12 +180,12 @@ fn trie_match_inner(input: ExprMatch) -> Result<TokenStream, Error> {
     let mut built_arms = vec![];
     let mut i = 0;
     for Arm {
-            attrs,
-            pat,
-            guard,
-            body,
-            ..
-        } in arms
+        attrs,
+        pat,
+        guard,
+        body,
+        ..
+    } in arms
     {
         #[cfg(feature = "cfg_attribute")]
         if !evaluate_cfg_attribute(&attrs)? {
@@ -192,8 +193,11 @@ fn trie_match_inner(input: ExprMatch) -> Result<TokenStream, Error> {
         }
         #[cfg(not(feature = "cfg_attribute"))]
         if let Some(attr) = attrs.first() {
-            return Err(Error::new(attr.span(), "attribute not supported here (Note: `#[cfg(...)]` \
-                attribute is supported on Nightly Rust. See the documentation)"));
+            return Err(Error::new(
+                attr.span(),
+                "attribute not supported here (Note: `#[cfg(...)]` \
+                attribute is supported on Nightly Rust. See the documentation)",
+            ));
         }
 
         if let Some((if_token, _)) = guard {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,6 @@ assert_eq!(result, 4);
 //! * The wildcard is evaluated last. (The normal `match` expression does not
 //!   match patterns after the wildcard.)
 //! * Pattern bindings are unavailable.
-//! * Attributes for match arms are unavailable.
 //! * Guards are unavailable.
 
 mod trie;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,8 +196,8 @@ fn trie_match_inner(input: ExprMatch) -> Result<TokenStream, Error> {
         if let Some(attr) = attrs.first() {
             return Err(Error::new(
                 attr.span(),
-                "attribute not supported here (Note: `#[cfg(...)]` \
-                attribute is supported on Nightly Rust. See the documentation)",
+                "attribute not supported here (Note: `#[cfg(...)]` attribute is supported only if \
+                the `cfg_attribute` feature is enabled. See the documentation)",
             ));
         }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -221,3 +221,31 @@ fn test_cfg_attribute() {
     assert_eq!(f("b"), 2);
     assert_eq!(f("c"), 2);
 }
+
+#[cfg(feature = "cfg_attribute")]
+#[test]
+fn test_cfg_attribute_combination() {
+    let f = |text| {
+        trie_match! {
+            match text {
+                #[cfg(test)]
+                #[cfg(feature = "cfg_attribute")]
+                "a" => 0,
+                #[cfg(not(test))]
+                #[cfg(feature = "cfg_attribute")]
+                "b" => 1,
+                #[cfg(test)]
+                #[cfg(not(feature = "cfg_attribute"))]
+                "c" => 2,
+                #[cfg(not(test))]
+                #[cfg(not(feature = "cfg_attribute"))]
+                "d" => 3,
+                _ => 4,
+            }
+        }
+    };
+    assert_eq!(f("a"), 0);
+    assert_eq!(f("b"), 4);
+    assert_eq!(f("c"), 4);
+    assert_eq!(f("d"), 4);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -125,3 +125,22 @@ fn test_try_base_conflict() {
     assert_eq!(f("\u{2}\u{3}"), 1);
     assert_eq!(f("\u{3}"), 1);
 }
+
+#[cfg(feature = "cfg_attribute")]
+#[test]
+fn test_cfg_attribute() {
+    let f = |text| {
+        trie_match! {
+            match text {
+                #[cfg(test)]
+                "a" => 0,
+                #[cfg(not(test))]
+                "b" => 1,
+                _ => 2,
+            }
+        }
+    };
+    assert_eq!(f("a"), 0);
+    assert_eq!(f("b"), 2);
+    assert_eq!(f("c"), 2);
+}


### PR DESCRIPTION
This pull request supports `#[cfg(...)]` attributes for conditional compilation.
This feature uses the [`proc_macro_expand`](https://github.com/rust-lang/rust/issues/90765) feature gate to evaluate attributes, so this feature is only available with Nightly Rust.

Fixes: #9 