### PR TITLE
Fix bug transitions from invalid checks

### DIFF
--- a/src/trie.rs
+++ b/src/trie.rs
@@ -131,6 +131,10 @@ impl<T> Sparse<T> {
                     continue 'a;
                 }
             }
+            // If edges allow all label values from x00 to xFF, such unreachable instances can be
+            // created. However, this would not happen in trie-match because only string literals
+            // are allowed, and xFF will never appear.
+            // (See hogehoge)
             unreachable!("No unused base found");
         }
         (bases, checks, values)

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -117,6 +117,22 @@ impl<T> Sparse<T> {
                 }
             }
         }
+        // Postprocessing to avoid invalid transitions due to invalid checks.
+        'a: for ((da_pos, check), &used) in checks.iter_mut().enumerate().zip(is_used.iter()) {
+            if da_pos != 0 && used {
+                continue;
+            }
+            let da_pos = i32::try_from(da_pos).unwrap();
+            for k in 0..256 {
+                let base = da_pos - k;
+                if !used_bases.contains(&base) {
+                    // There can be no transition using k from an unused BASE value.
+                    *check = u8::try_from(k).unwrap();
+                    continue 'a;
+                }
+            }
+            unreachable!("No unused base found");
+        }
         (bases, checks, values)
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -129,6 +129,11 @@ fn test_try_base_conflict() {
 // This test confirms that check[0] does not have an invalid value of zero.
 #[test]
 fn test_invalid_root_check() {
+    // [0] -x01-> [1]
+    //    \-x00-> [0] ? If check[0] is 0, such an invalid transition is possible.
+    //
+    //  base: [0, MAX]
+    // check: [0,   1]
     let f = |text| {
         trie_match! {
             match text {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -125,3 +125,17 @@ fn test_try_base_conflict() {
     assert_eq!(f("\u{2}\u{3}"), 1);
     assert_eq!(f("\u{3}"), 1);
 }
+
+// This test confirms that check[0] does not have an invalid value of zero.
+#[test]
+fn test_invalid_root_check() {
+    let f = |text| {
+        trie_match! {
+            match text {
+                "\u{1}" => 1,
+                _ => 0,
+            }
+        }
+    };
+    assert_eq!(f("\u{0}\u{1}"), 0);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -128,7 +128,7 @@ fn test_try_base_conflict() {
 
 // This test confirms that check[0] does not have an invalid value of zero.
 #[test]
-fn test_invalid_root_check() {
+fn test_invalid_root_check_of_zero() {
     // [0] -x01-> [1]
     //    \-x00-> [0] ? If check[0] is 0, such an invalid transition is possible.
     //


### PR DESCRIPTION
This PR fixes a bug from invalid checks initialized with zero.

Let us assume a trie for a pattern `(0x01)`. We will obtain the following BASE&CHECK when CHECK values are initialized with zero.

```
 TRIE: [0] -0x01-> [1]

 BASE: [0, MAX]
CHECK: [0,   1]
```

In this case, an invalid transition `[0] -0x00-> [0]` is allowed because `CHECK[0] == 0x00`. This is a bug.

This PR suggests a simple solution using `0xFF` for the invalid CHECK value because trie-match allows only string literal patterns in UTF-8, and `0xFF` will be never used.