### PR TITLE
Support bound variables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-match"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 
 # Update README and CI settings, accordingly.

--- a/README.md
+++ b/README.md
@@ -19,15 +19,17 @@ use trie_match::trie_match;
 
 let x = "abd";
 
-trie_match! {
+let result = trie_match! {
     match x {
-        "a" => { println!("x"); }
-        "abc" => { println!("y"); }
-        "abd" | "bcc" => { println!("z"); }
-        "bc" => { println!("w"); }
-        _ => { println!(" "); }
+        "a" => 0,
+        "abc" => 1,
+        pat @ ("abd" | "bcc") => pat.bytes()[0],
+        "bc" => 3,
+        _ => 4,
     }
-}
+};
+
+assert_eq!(result, 3);
 ```
 
 ## Why is it faster?
@@ -37,15 +39,15 @@ equivalent to the following code:
 
 ```rust
 if x == "a" {
-    ..
+    0
 } else if x == "abc" {
-    ..
+    1
 } else if x == "abd" || x == "bcc" {
-    ..
+    x.bytes()[0]
 } else if x == "bc" {
-    ..
+    3
 } else {
-    ..
+    4
 }
 ```
 
@@ -89,7 +91,6 @@ The followings are different from the normal `match` expression:
 * Only supports strings, byte strings, and u8 slices as patterns.
 * The wildcard is evaluated last. (The normal `match` expression does not
   match patterns after the wildcard.)
-* Pattern bindings are unavailable.
 * Guards are unavailable.
 
 Sometimes the normal `match` expression is faster, depending on how

--- a/benches/match.rs
+++ b/benches/match.rs
@@ -273,7 +273,7 @@ fn criterion_word100(c: &mut Criterion) {
         b.iter(|| {
             let mut x = 0;
             for s in &word_100 {
-                trie_match!(match s {
+                trie_match!(match s.as_str() {
                     "stampeding" | "commendable" | "adrenaline" | "exobiology" | "indifference"
                     | "avuncular" | "prevailed" | "foreparts" | "legalistically"
                     | "intermarries" | "desideratum" | "evaluating" | "lavishing"
@@ -317,7 +317,7 @@ fn criterion_word100(c: &mut Criterion) {
         b.iter(|| {
             let mut x = 0;
             for s in &word_100 {
-                trie_match!(match s {
+                trie_match!(match s.as_str() {
                     "stampeding" | "commendable" | "adrenaline" | "exobiology" | "indifference"
                     | "avuncular" | "prevailed" | "foreparts" | "legalistically"
                     | "intermarries" | "desideratum" | "evaluating" | "lavishing"
@@ -361,7 +361,7 @@ fn criterion_word100(c: &mut Criterion) {
         b.iter(|| {
             let mut x = 0;
             for s in &word_100 {
-                trie_match!(match s {
+                trie_match!(match s.as_str() {
                     "stampeding" | "commendable" | "adrenaline" | "exobiology" | "indifference"
                     | "avuncular" | "prevailed" | "foreparts" | "legalistically"
                     | "intermarries" | "desideratum" | "evaluating" | "lavishing"
@@ -678,7 +678,7 @@ fn criterion_html_elements(c: &mut Criterion) {
         b.iter(|| {
             let mut x = 0;
             for s in &html_elements {
-                trie_match!(match s {
+                trie_match!(match s.as_str() {
                     "bdo" | "rb" | "th" | "ul" | "pre" | "mark" | "em" | "search" | "head"
                     | "li" | "del" | "details" | "p" | "bdi" | "time" | "area" | "br" | "var"
                     | "aside" | "main" | "tfoot" | "hr" | "label" | "rp" | "menuitem" => {
@@ -719,7 +719,7 @@ fn criterion_html_elements(c: &mut Criterion) {
         b.iter(|| {
             let mut x = 0;
             for s in &html_elements {
-                trie_match!(match s {
+                trie_match!(match s.as_str() {
                     "bdo" | "rb" | "th" | "ul" | "pre" | "mark" | "em" | "search" | "head"
                     | "li" | "del" | "details" | "p" | "bdi" | "time" | "area" | "br" | "var"
                     | "aside" | "main" | "tfoot" | "hr" | "label" | "rp" | "menuitem" => {
@@ -760,7 +760,7 @@ fn criterion_html_elements(c: &mut Criterion) {
         b.iter(|| {
             let mut x = 0;
             for s in &html_elements {
-                trie_match!(match s {
+                trie_match!(match s.as_str() {
                     "bdo" | "rb" | "th" | "ul" | "pre" | "mark" | "em" | "search" | "head"
                     | "li" | "del" | "details" | "p" | "bdi" | "time" | "area" | "br" | "var"
                     | "aside" | "main" | "tfoot" | "hr" | "label" | "rp" | "menuitem" => {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -203,6 +203,26 @@ fn test_slice_ref_numbers() {
     assert_eq!(f(&[0, 1]), 1);
 }
 
+#[test]
+fn test_binds() {
+    let f = |text| {
+        trie_match! {
+            match text {
+                x @ "abc" | x @ "def" => &x[1..],
+                y @ ("ghi" | "jkl") => &y[2..],
+                z @ "xyzw" => &z[3..],
+                w => &w[4..],
+            }
+        }
+    };
+    assert_eq!(f("abc"), "bc");
+    assert_eq!(f("def"), "ef");
+    assert_eq!(f("ghi"), "i");
+    assert_eq!(f("jkl"), "l");
+    assert_eq!(f("xyzw"), "w");
+    assert_eq!(f("abcdefg"), "efg");
+}
+
 #[cfg(feature = "cfg_attribute")]
 #[test]
 fn test_cfg_attribute() {


### PR DESCRIPTION
This branch supports bound variables. For example:
```rust
trie_match! {
    match text {
        x @ "abc" | x @ "def" => &x[1..],
        y @ ("ghi" | "jkl") => &y[2..],
        z @ "xyzw" => &z[3..],
        w => &w[4..],
    }
}
```

The following code will fail to compile:
```rust
trie_match! {
    match text {
        x @ "abc" | y @ "def" => &x[1..],  // variable is not bound in all patterns.
        y @ "ghi" | "jkl" => &y[2..],  // variable is not bound in all patterns.
        w => &w[4..],
    }
}
```

This change wraps the implementation in a normal `match` expression to ensure that type inference works as expected.
In the previous implementation, implicit type conversion has been performed, which is not done in normal `match` expressions, but this change makes type checking as strict as in normal `match` expressions.
Backward compatibility will be broken, so this change increments the version number.